### PR TITLE
Fixes and improvements to Infested Marines gamemode

### DIFF
--- a/InfestedMarines/source/lua/IMAlienTeam.lua
+++ b/InfestedMarines/source/lua/IMAlienTeam.lua
@@ -1,0 +1,13 @@
+-- ========================
+--
+-- lua\AlienTeam.lua
+--
+--    Created by:  telemancer
+--
+-- ========================
+
+
+function AlienTeam:OnResetComplete()
+-- Emptying this function prevents the call to DestroyPowerForLocation
+-- that would destroy the alien start power node in a normal game.
+end

--- a/InfestedMarines/source/lua/IMCyst_Server.lua
+++ b/InfestedMarines/source/lua/IMCyst_Server.lua
@@ -13,16 +13,24 @@ end
 function Cyst:OnEntityChange(entityId, newEntityId)
 end
 
-local old_Cyst_OnKill = Cyst.OnKill
 function Cyst:OnKill(attacker, doer, point, direction)
     
-    if doer and (doer:isa("Flamethrower") or doer:isa("Welder")) then
+    -- Handle OnKill for this cyst
+	self:TriggerEffects("death")
+	self.connected = false
+	self:SetModel(nil)
+	self:Kill()
+	
+    if doer and doer:isa("Flamethrower") then
         -- kill all cysts within IMCystManager.kCystConnectionRadius, to make clearing easier
         -- and also as a workaround for the unreachable cyst issue.
         local cysts = GetEntitiesWithinRange("Cyst", self:GetOrigin(), IMCystManager.kCystConnectionRadius)
         for i=1, #cysts do
-            if cysts[i] and cysts[i] ~= self and cysts[i].GetIsAlive and cysts[i]:GetIsAlive() then
-                cysts[i]:Kill()
+            if cysts[i] and cysts[i] ~= self and cysts[i].GetIsAlive then
+				cysts[i]:TriggerEffects("death")
+				cysts[i].connected = false
+				cysts[i]:SetModel(nil)
+				cysts[i]:Kill()
             end
         end
     end
@@ -30,8 +38,6 @@ function Cyst:OnKill(attacker, doer, point, direction)
     GetCystManager():CreateAreaOfDenial(self:GetOrigin())
     
     TipHandler_ReportCystKilled(attacker)
-    
-    old_Cyst_OnKill(self, attacker, doer, point, direction)
     
 end
 

--- a/InfestedMarines/source/lua/IMGUIScoreboard.lua
+++ b/InfestedMarines/source/lua/IMGUIScoreboard.lua
@@ -298,13 +298,11 @@ function GUIScoreboard:UpdateTeam(updateTeam)
         end
         
         local statusPos = ConditionalValue(GUIScoreboard.screenWidth < 1280, GUIScoreboard.kPlayerItemWidth + 30, (self:GetTeamItemWidth() - GUIScoreboard.kTeamColumnSpacingX * 10) + 60)
-        if isSpectator then
-			playerStatus = "Spectator"
-			player["Status"]:SetText(playerStatus)
+	if isSpectator and teamNumber ~= 1 and teamNumber ~= 2 and not isDead then
+	    player["Status"]:SetText("Spectator")
             statusPos = statusPos + GUIScoreboard.kTeamColumnSpacingX * ConditionalValue(GUIScoreboard.screenWidth < 1280, 2.75, 1.75)
-        elseif playerStatus == "-" or (playerStatus ~= Locale.ResolveString("STATUS_SPECTATOR") and teamNumber ~= 1 and teamNumber ~= 2) then
-            playerStatus = ""
-            player["Status"]:SetText(playerStatus)
+        else
+            player["Status"]:SetText("")
             statusPos = statusPos + GUIScoreboard.kTeamColumnSpacingX * ConditionalValue(GUIScoreboard.screenWidth < 1280, 2.75, 1.75)
         end
         

--- a/InfestedMarines/source/lua/IMGameMaster.lua
+++ b/InfestedMarines/source/lua/IMGameMaster.lua
@@ -250,9 +250,9 @@ end
 
 local function PerformNodeDamage(self)
     
-    if self.phase == IMGameMaster.kPhase.Scatter then
+    if self:GetPhase() == IMGameMaster.kPhase.Scatter then
         PerformScatterNodeDamage(self)
-    elseif self.phase == IMGameMaster.kPhase.Regroup then
+    elseif self:GetPhase() == IMGameMaster.kPhase.Regroup then
         PerformRegroupNodeDamage(self)
     else
         assert(false)

--- a/InfestedMarines/source/lua/IMHooks.lua
+++ b/InfestedMarines/source/lua/IMHooks.lua
@@ -11,6 +11,7 @@ Script.Load("lua/IMModBlacklist.lua")
 
 ModLoader.SetupFileHook( "lua/DeathMessage_Client.lua", "lua/IMDeathMessage_Client.lua", "replace" )
 
+ModLoader.SetupFileHook("lua/AlienTeam.lua", "lua/IMAlienTeam.lua", "post")
 ModLoader.SetupFileHook("lua/NS2Gamerules.lua", "lua/IMNS2Gamerules.lua", "post")
 ModLoader.SetupFileHook("lua/Marine_Server.lua", "lua/IMMarine_Server.lua", "post")
 ModLoader.SetupFileHook("lua/Marine_Client.lua", "lua/IMMarine_Client.lua", "post")

--- a/InfestedMarines/source/lua/IMNS2Gamerules.lua
+++ b/InfestedMarines/source/lua/IMNS2Gamerules.lua
@@ -55,7 +55,7 @@ if Server then
     end
     
     function NS2Gamerules:GetPregameLength()
-        return 0
+        return 10
     end
     
     -- disable bots for this gamemode
@@ -367,7 +367,8 @@ if Server then
                 self.team2:PlayPrivateTeamSound(ConditionalValue(self.team2:GetTeamType() == kAlienTeamType, NS2Gamerules.kAlienStartSound, NS2Gamerules.kMarineStartSound))
                 
                 self:SetGameState(kGameState.Started)
-                self.sponitor:OnStartMatch()
+                -- temporarily disabled for throwing errors
+                -- self.sponitor:OnStartMatch()
                 self.playerRanking:StartGame()
                 
                 GetGameMaster():DoGameStart()
@@ -383,8 +384,17 @@ if Server then
         local state = self:GetGameState()
         if(state == kGameState.Team1Won or state == kGameState.Team2Won or state == kGameState.Draw) and (not self.concedeStartTime) then
             if self.timeSinceGameStateChanged >= kTimeToReadyRoom then
+                
                 -- reset teams
                 self:ResetGame()
+                
+               -- Send all players back to ready room so game doesn't auto start
+				for index, player in ientitylist(Shared.GetEntitiesWithClassname("Player")) do
+					if not player:GetIsSpectator() then
+						self::JoinTeam(player, kTeamReadyRoom, force)
+                        -- GetGamerules():JoinTeam(player, kTeamReadyRoom)
+					end
+				end
             end
         end
     end

--- a/InfestedMarines/source/lua/IMNS2Gamerules.lua
+++ b/InfestedMarines/source/lua/IMNS2Gamerules.lua
@@ -388,13 +388,14 @@ if Server then
                 -- reset teams
                 self:ResetGame()
                 
-               -- Send all players back to ready room so game doesn't auto start
-				for index, player in ientitylist(Shared.GetEntitiesWithClassname("Player")) do
-					if not player:GetIsSpectator() then
-						self::JoinTeam(player, kTeamReadyRoom, force)
+                -- Send all players back to ready room so game doesn't auto start
+		for index, player in ientitylist(Shared.GetEntitiesWithClassname("Player")) do
+		    if not player:GetIsSpectator() then
+		        self::JoinTeam(player, kTeamReadyRoom, force)
                         -- GetGamerules():JoinTeam(player, kTeamReadyRoom)
-					end
-				end
+		    end
+		end
+
             end
         end
     end

--- a/InfestedMarines/source/lua/IMNS2Gamerules.lua
+++ b/InfestedMarines/source/lua/IMNS2Gamerules.lua
@@ -387,14 +387,6 @@ if Server then
                 
                 -- reset teams
                 self:ResetGame()
-                
-                -- Send all players back to ready room so game doesn't auto start
-		for index, player in ientitylist(Shared.GetEntitiesWithClassname("Player")) do
-		    if not player:GetIsSpectator() then
-		        self::JoinTeam(player, kTeamReadyRoom, force)
-                        -- GetGamerules():JoinTeam(player, kTeamReadyRoom)
-		    end
-		end
 
             end
         end
@@ -407,6 +399,13 @@ if Server then
         
         GetGameMaster():OnRoundEnd(...)
         self:ResetPlayerScores()
+		
+	-- Send all players back to ready room so game doesn't auto start
+	for index, player in ientitylist(Shared.GetEntitiesWithClassname("Player")) do
+	    if not player:GetIsSpectator() then
+	        self::JoinTeam(player, kTeamReadyRoom, force)
+            end
+	end
     end
 
     -- Alive players hear only alive players, dead players only hear dead players

--- a/InfestedMarines/source/lua/IMNS2Gamerules.lua
+++ b/InfestedMarines/source/lua/IMNS2Gamerules.lua
@@ -384,10 +384,8 @@ if Server then
         local state = self:GetGameState()
         if(state == kGameState.Team1Won or state == kGameState.Team2Won or state == kGameState.Draw) and (not self.concedeStartTime) then
             if self.timeSinceGameStateChanged >= kTimeToReadyRoom then
-                
                 -- reset teams
                 self:ResetGame()
-
             end
         end
     end
@@ -402,7 +400,7 @@ if Server then
 		
 	-- Send all players back to ready room so game doesn't auto start
 	for index, player in ientitylist(Shared.GetEntitiesWithClassname("Player")) do
-	    if not player:GetIsSpectator() then
+	    if player:GetTeamNumber() == kTeam1Index or player:GetTeamNumber() == kTeam2Index then
 	        self::JoinTeam(player, kTeamReadyRoom, force)
             end
 	end

--- a/InfestedMarines/source/lua/IMNS2Gamerules.lua
+++ b/InfestedMarines/source/lua/IMNS2Gamerules.lua
@@ -401,8 +401,8 @@ if Server then
 	-- Send all players back to ready room so game doesn't auto start
 	for index, player in ientitylist(Shared.GetEntitiesWithClassname("Player")) do
 	    if player:GetTeamNumber() == kTeam1Index or player:GetTeamNumber() == kTeam2Index then
-	        self::JoinTeam(player, kTeamReadyRoom, force)
-            end
+	        self:JoinTeam(player, kTeamReadyRoom, true)
+	    end
 	end
     end
 


### PR DESCRIPTION
Fixed cysts not being being destroyed by moving the onkill handling code into IMCystServer.
Altered the behavior so only the flamethrower has splash damage and can kill multiple cysts at a time, the welder behaves normally.

Created IMAlienTeam.lua to blank out the AlienTeam:OnResetComplete() method, therefore preventing the destruction of the alien start point power node at the beginning of the game.

Updated the performnodedamage method to use the getter method to check kphase instead of accessing it directly, as it was throwing errors by getting called before being set, and the getter sets the phase if its not already.

Added a buffer time between rounds by moving all players to the ready room at the end of a game, and adding 10 seconds to  pregame time.

Changed a whole lot with scoreboard to fix badges not showing, remove dead code, and make it so ready room spectators are labeled spectators, but not dead players spectators. That way, living marine players cant see who is dead, but can see who is in ready room vs spectate, which is useful to see who is actually in a spectator slot.

Disabled sponitor because it was causing me too many issues. TBH, I dont even know what it does, but if its important, somebody should go back in and fix it.